### PR TITLE
Fixes TNB Analysis logo link

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
                 </picture>
             </div>
             <div class="heading">
-                <a href="/">
+                <a href="/tnb-analysis">
                     <h3>TNB Analysis</h3>
                 </a>
             </div>


### PR DESCRIPTION
Sorry, the previous PR redirected the logo to the root url of the Github pages site. Hadn't tested it on GitHub pages. 😅  This should fix it.